### PR TITLE
[#18] persistence 구현체를 bean에 등록

### DIFF
--- a/src/main/java/org/wedding/adapter/out/persistence/MybatisUserRepositoryImpl.java
+++ b/src/main/java/org/wedding/adapter/out/persistence/MybatisUserRepositoryImpl.java
@@ -3,9 +3,11 @@ package org.wedding.adapter.out.persistence;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
 import org.wedding.domain.user.User;
 import org.wedding.application.port.out.repository.UserRepository;
 
+@Repository
 @Mapper
 public interface MybatisUserRepositoryImpl extends UserRepository {
     @Override

--- a/src/main/java/org/wedding/application/port/out/repository/UserRepository.java
+++ b/src/main/java/org/wedding/application/port/out/repository/UserRepository.java
@@ -2,10 +2,8 @@ package org.wedding.application.port.out.repository;
 
 import java.util.Optional;
 
-import org.springframework.stereotype.Repository;
 import org.wedding.domain.user.User;
 
-@Repository
 public interface UserRepository {
     int save(User user);
 


### PR DESCRIPTION
### Isuue Number: 
#18

## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.
- 향후 persistence 기술이 변경 되어도 다른 모듈에 영향을 최소화하기 위해 persistence 상위 인터페이스가 의존성 역전 시키도록
persistence 구현체를 bean 에 등록한다.

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.
- 상위 인터페이스에 선언한 @Repository 어노테이션을 제거하고 구현체에 선언
- ORM 명칭이 드러나도록 클래스 명 수정

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.